### PR TITLE
Add S3 permissions

### DIFF
--- a/permissions/s3-protection/1002.json
+++ b/permissions/s3-protection/1002.json
@@ -1,0 +1,79 @@
+{
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        {
+          "Permission": "s3:ListAllMyBuckets",
+          "UseCases": ["Retrieving the list of S3 buckets."]
+        },
+        {
+          "Permission": "s3:ListBucket",
+          "UseCases": ["Listing the objects in S3 buckets."]
+        },
+        {
+          "Permission": "s3:GetObject",
+          "UseCases": ["Retrieving the object from S3 buckets."]
+        },
+        {
+          "Permission": "s3:GetBucketTagging",
+          "UseCases": ["Retrieving the tag set associated with S3 bucket."]
+        },
+        {
+          "Permission": "s3:PutObject",
+          "UseCases": ["Adding an object to S3 bucket."]
+        },
+        {
+          "Permission": "s3:AbortMultipartUpload",
+          "UseCases": ["Aborting a multipart upload process"]
+        },
+        {
+          "Permission": "s3:GetBucketLocation",
+          "UseCases": ["Retrieving the bucket region."]
+        },
+        {
+          "Permission": "s3:CreateBucket",
+          "UseCases": ["Creating S3 bucket."]
+        },
+        {
+          "Permission": "s3:ListBucketMultipartUploads",
+          "UseCases": ["Listing all the multipart upload processes."]
+        },
+        {
+          "Permission": "s3:PutBucketTagging",
+          "UseCases": ["Adding a set of tags to S3 bucket."]
+        },
+        {
+          "Permission": "s3:GetObjectAttributes",
+          "UseCases": ["Retrieving attributes related to an S3 object.."]
+        },
+        {
+          "Permission": "s3:GetObjectTagging",
+          "UseCases": ["Retrieving tag set of an S3 object."]
+        },
+        {
+          "Permission": "s3:PutObjectTagging",
+          "UseCases": ["Setting a tag set to an S3 object."]
+        },
+        {
+          "Permission": "s3:ListMultipartUploadParts",
+          "UseCases": ["Listing all the parts for a multipart upload process."]
+        },
+        {
+          "Permission": "s3:GetObjectAcl",
+          "UseCases": ["Retrieving access control list of an S3 object."]
+        },
+        {
+          "Permission": "s3:PutObjectAcl",
+          "UseCases": ["Setting the access control list for an S3 object."]
+        },
+        {
+          "Permission": "s3:GetBucketOwnershipControls",
+          "UseCases": ["Getting the bucket ownership controls."]
+        }
+      ],
+      "Resource": ["*"]
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/permissions/s3-protection/1003.json
+++ b/permissions/s3-protection/1003.json
@@ -1,0 +1,83 @@
+{
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        {
+          "Permission": "s3:ListAllMyBuckets",
+          "UseCases": ["Retrieving the list of S3 buckets."]
+        },
+        {
+          "Permission": "s3:ListBucket",
+          "UseCases": ["Listing the objects in S3 buckets."]
+        },
+        {
+          "Permission": "s3:GetObject",
+          "UseCases": ["Retrieving the object from S3 buckets."]
+        },
+        {
+          "Permission": "s3:GetBucketTagging",
+          "UseCases": ["Retrieving the tag set associated with S3 bucket."]
+        },
+        {
+          "Permission": "s3:PutObject",
+          "UseCases": ["Adding an object to S3 bucket."]
+        },
+        {
+          "Permission": "s3:AbortMultipartUpload",
+          "UseCases": ["Aborting a multipart upload process"]
+        },
+        {
+          "Permission": "s3:GetBucketLocation",
+          "UseCases": ["Retrieving the bucket region."]
+        },
+        {
+          "Permission": "s3:CreateBucket",
+          "UseCases": ["Creating S3 bucket."]
+        },
+        {
+          "Permission": "s3:ListBucketMultipartUploads",
+          "UseCases": ["Listing all the multipart upload processes."]
+        },
+        {
+          "Permission": "s3:PutBucketTagging",
+          "UseCases": ["Adding a set of tags to S3 bucket."]
+        },
+        {
+          "Permission": "s3:GetObjectAttributes",
+          "UseCases": ["Retrieving attributes related to an S3 object.."]
+        },
+        {
+          "Permission": "s3:GetObjectTagging",
+          "UseCases": ["Retrieving tag set of an S3 object."]
+        },
+        {
+          "Permission": "s3:PutObjectTagging",
+          "UseCases": ["Setting a tag set to an S3 object."]
+        },
+        {
+          "Permission": "s3:ListMultipartUploadParts",
+          "UseCases": ["Listing all the parts for a multipart upload process."]
+        },
+        {
+          "Permission": "s3:GetObjectAcl",
+          "UseCases": ["Retrieving access control list of an S3 object."]
+        },
+        {
+          "Permission": "s3:PutObjectAcl",
+          "UseCases": ["Setting the access control list for an S3 object."]
+        },
+        {
+          "Permission": "s3:GetBucketOwnershipControls",
+          "UseCases": ["Getting the bucket ownership controls."]
+        },
+        {
+          "Permission": "s3:PutObjectVersionTagging",
+          "UseCases": ["Setting a tag set to an S3 object version."]
+        }
+      ],
+      "Resource": ["*"]
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/permissions/s3-protection/1004.json
+++ b/permissions/s3-protection/1004.json
@@ -1,0 +1,91 @@
+{
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        {
+          "Permission": "s3:ListAllMyBuckets",
+          "UseCases": ["Retrieving the list of S3 buckets."]
+        },
+        {
+          "Permission": "s3:ListBucket",
+          "UseCases": ["Listing the objects in S3 buckets."]
+        },
+        {
+          "Permission": "s3:GetObject",
+          "UseCases": ["Retrieving the object from S3 buckets."]
+        },
+        {
+          "Permission": "s3:GetBucketTagging",
+          "UseCases": ["Retrieving the tag set associated with S3 bucket."]
+        },
+        {
+          "Permission": "s3:PutObject",
+          "UseCases": ["Adding an object to S3 bucket."]
+        },
+        {
+          "Permission": "s3:AbortMultipartUpload",
+          "UseCases": ["Aborting a multipart upload process"]
+        },
+        {
+          "Permission": "s3:GetBucketLocation",
+          "UseCases": ["Retrieving the bucket region."]
+        },
+        {
+          "Permission": "s3:CreateBucket",
+          "UseCases": ["Creating S3 bucket."]
+        },
+        {
+          "Permission": "s3:ListBucketMultipartUploads",
+          "UseCases": ["Listing all the multipart upload processes."]
+        },
+        {
+          "Permission": "s3:PutBucketTagging",
+          "UseCases": ["Adding a set of tags to S3 bucket."]
+        },
+        {
+          "Permission": "s3:GetObjectAttributes",
+          "UseCases": ["Retrieving attributes related to an S3 object.."]
+        },
+        {
+          "Permission": "s3:GetObjectTagging",
+          "UseCases": ["Retrieving tag set of an S3 object."]
+        },
+        {
+          "Permission": "s3:PutObjectTagging",
+          "UseCases": ["Setting a tag set to an S3 object."]
+        },
+        {
+          "Permission": "s3:ListMultipartUploadParts",
+          "UseCases": ["Listing all the parts for a multipart upload process."]
+        },
+        {
+          "Permission": "s3:GetObjectAcl",
+          "UseCases": ["Retrieving access control list of an S3 object."]
+        },
+        {
+          "Permission": "s3:PutObjectAcl",
+          "UseCases": ["Setting the access control list for an S3 object."]
+        },
+        {
+          "Permission": "s3:GetBucketOwnershipControls",
+          "UseCases": ["Getting the bucket ownership controls."]
+        },
+        {
+          "Permission": "s3:PutBucketOwnershipControls",
+          "UseCases": ["Setting the bucket ownership controls."]
+        },
+        {
+          "Permission": "s3:PutObjectVersionTagging",
+          "UseCases": ["Setting a tag set to an S3 object version."]
+        },
+        {
+          "Permission": "s3:PutBucketVersioning",
+          "UseCases": ["Setting versioning for a bucket."]
+        }
+      ],
+      "Resource": ["*"]
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/permissions/s3-protection/1005.json
+++ b/permissions/s3-protection/1005.json
@@ -1,0 +1,101 @@
+{
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        {
+          "Permission": "s3:ListAllMyBuckets",
+          "UseCases": ["Retrieving the list of S3 buckets."]
+        },
+        {
+          "Permission": "s3:ListBucket",
+          "UseCases": ["Listing the objects in S3 buckets."]
+        },
+        {
+          "Permission": "s3:GetObject",
+          "UseCases": ["Retrieving the object from S3 buckets."]
+        },
+        {
+          "Permission": "s3:GetBucketTagging",
+          "UseCases": ["Retrieving the tag set associated with S3 bucket."]
+        },
+        {
+          "Permission": "s3:PutObject",
+          "UseCases": ["Adding an object to S3 bucket."]
+        },
+        {
+          "Permission": "s3:AbortMultipartUpload",
+          "UseCases": ["Aborting a multipart upload process"]
+        },
+        {
+          "Permission": "s3:GetBucketLocation",
+          "UseCases": ["Retrieving the bucket region."]
+        },
+        {
+          "Permission": "s3:CreateBucket",
+          "UseCases": ["Creating S3 bucket."]
+        },
+        {
+          "Permission": "s3:ListBucketMultipartUploads",
+          "UseCases": ["Listing all the multipart upload processes."]
+        },
+        {
+          "Permission": "s3:PutBucketTagging",
+          "UseCases": ["Adding a set of tags to S3 bucket."]
+        },
+        {
+          "Permission": "s3:GetObjectAttributes",
+          "UseCases": ["Retrieving attributes related to an S3 object.."]
+        },
+        {
+          "Permission": "s3:GetObjectTagging",
+          "UseCases": ["Retrieving tag set of an S3 object."]
+        },
+        {
+          "Permission": "s3:PutObjectTagging",
+          "UseCases": ["Setting a tag set to an S3 object."]
+        },
+        {
+          "Permission": "s3:ListMultipartUploadParts",
+          "UseCases": ["Listing all the parts for a multipart upload process."]
+        },
+        {
+          "Permission": "s3:GetObjectAcl",
+          "UseCases": ["Retrieving access control list of an S3 object."]
+        },
+        {
+          "Permission": "s3:PutObjectAcl",
+          "UseCases": ["Setting the access control list for an S3 object."]
+        },
+        {
+          "Permission": "s3:GetBucketOwnershipControls",
+          "UseCases": ["Getting the bucket ownership controls."]
+        },
+        {
+          "Permission": "s3:PutBucketOwnershipControls",
+          "UseCases": ["Setting the bucket ownership controls."]
+        },
+        {
+          "Permission": "s3:PutObjectVersionTagging",
+          "UseCases": ["Setting a tag set to an S3 object version."]
+        },
+        {
+          "Permission": "s3:PutBucketVersioning",
+          "UseCases": ["Setting versioning for a bucket."]
+        }
+      ],
+      "Resource": ["*"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        {
+          "Permission": "cloudwatch:GetMetricStatistics",
+          "UseCases": ["Fetching usage metrics."]
+        }
+      ],
+      "Resource": ["*"]
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/permissions/s3-protection/1006.json
+++ b/permissions/s3-protection/1006.json
@@ -1,0 +1,105 @@
+{
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        {
+          "Permission": "s3:ListAllMyBuckets",
+          "UseCases": ["Retrieving the list of S3 buckets."]
+        },
+        {
+          "Permission": "s3:ListBucket",
+          "UseCases": ["Listing the objects in S3 buckets."]
+        },
+        {
+          "Permission": "s3:GetObject",
+          "UseCases": ["Retrieving the object from S3 buckets."]
+        },
+        {
+          "Permission": "s3:GetBucketTagging",
+          "UseCases": ["Retrieving the tag set associated with S3 bucket."]
+        },
+        {
+          "Permission": "s3:PutObject",
+          "UseCases": ["Adding an object to S3 bucket."]
+        },
+        {
+          "Permission": "s3:AbortMultipartUpload",
+          "UseCases": ["Aborting a multipart upload process"]
+        },
+        {
+          "Permission": "s3:GetBucketLocation",
+          "UseCases": ["Retrieving the bucket region."]
+        },
+        {
+          "Permission": "s3:CreateBucket",
+          "UseCases": ["Creating S3 bucket."]
+        },
+        {
+          "Permission": "s3:ListBucketMultipartUploads",
+          "UseCases": ["Listing all the multipart upload processes."]
+        },
+        {
+          "Permission": "s3:PutBucketTagging",
+          "UseCases": ["Adding a set of tags to S3 bucket."]
+        },
+        {
+          "Permission": "s3:GetObjectAttributes",
+          "UseCases": ["Retrieving attributes related to an S3 object.."]
+        },
+        {
+          "Permission": "s3:GetObjectTagging",
+          "UseCases": ["Retrieving tag set of an S3 object."]
+        },
+        {
+          "Permission": "s3:PutObjectTagging",
+          "UseCases": ["Setting a tag set to an S3 object."]
+        },
+        {
+          "Permission": "s3:ListMultipartUploadParts",
+          "UseCases": ["Listing all the parts for a multipart upload process."]
+        },
+        {
+          "Permission": "s3:GetObjectAcl",
+          "UseCases": ["Retrieving access control list of an S3 object."]
+        },
+        {
+          "Permission": "s3:PutObjectAcl",
+          "UseCases": ["Setting the access control list for an S3 object."]
+        },
+        {
+          "Permission": "s3:GetBucketOwnershipControls",
+          "UseCases": ["Getting the bucket ownership controls."]
+        },
+        {
+          "Permission": "s3:PutBucketOwnershipControls",
+          "UseCases": ["Setting the bucket ownership controls."]
+        },
+        {
+          "Permission": "s3:PutObjectVersionTagging",
+          "UseCases": ["Setting a tag set to an S3 object version."]
+        },
+        {
+          "Permission": "s3:PutBucketVersioning",
+          "UseCases": ["Setting versioning for a bucket."]
+        },
+        {
+          "Permission": "s3:PutInventoryConfiguration",
+          "UseCases": ["Configuring inventory for a bucket"]
+        }
+      ],
+      "Resource": ["*"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        {
+          "Permission": "cloudwatch:GetMetricStatistics",
+          "UseCases": ["Fetching usage metrics."]
+        }
+      ],
+      "Resource": ["*"]
+    }
+  ],
+  "Version": "2012-10-17"
+}


### PR DESCRIPTION
# Description

Adds required permissions for AWS S3

## Related Issue

SPARK-532643

## Motivation and Context

Currently AWS S3 permissions aren't listed here. This PR adds the respective permissions needed for each version

## How Has This Been Tested?

Unit tests were missing for AWS S3 permissions. Added UTs and tested the branch against them.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/fd353c6e-0122-41eb-ab7c-e763586cdba5)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/welcome-to-rubrik-build/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
