### PR TITLE
Add s3:PutBucketPolicy to archival permissions

### DIFF
--- a/permissions/archival/7.json
+++ b/permissions/archival/7.json
@@ -1,0 +1,194 @@
+{
+	"Statement": [
+		{
+			"Sid": "archivalStoragePermissions",
+			"Effect": "Allow",
+			"Action": [
+				{
+					"Permission": "s3:CreateBucket",
+					"UseCases": [
+						"To create the archival location."
+					]
+				},
+				{
+					"Permission": "s3:PutObject",
+					"UseCases": [
+						"To upload backup data to the archival location."
+					]
+				},
+				{
+					"Permission": "s3:GetObject",
+					"UseCases": [
+						"To read archived snapshot data from the archival location."
+					]
+				},
+				{
+					"Permission": "s3:ListBucket",
+					"UseCases": [
+						"To list archival locations and verify connectivity to the archival location."
+					]
+				},
+				{
+					"Permission": "s3:GetBucketLocation",
+					"UseCases": [
+						"To read the region in which the S3 bucket resides."
+					]
+				},
+				{
+					"Permission": "s3:AbortMultipartUpload",
+					"UseCases": [
+						"To perform the multipart upload."
+					]
+				},
+				{
+					"Permission": "s3:ListMultipartUploadParts",
+					"UseCases": [
+						"To list the in-progress multipart uploads."
+					]
+				},
+				{
+					"Permission": "s3:RestoreObject",
+					"UseCases": [
+						"To recover data from archived snapshots."
+					]
+				},
+				{
+					"Permission": "s3:GetObjectVersion",
+					"UseCases": [
+						"To read from S3 buckets with versioning and immutability enabled."
+					]
+				},
+				{
+					"Permission": "s3:GetObjectRetention",
+					"UseCases": [
+						"To retrieve the details of an object lock."
+					]
+				},
+				{
+					"Permission": "s3:GetBucketVersioning",
+					"UseCases": [
+						"To retrieve the versioning status of an S3 bucket."
+					]
+				},
+				{
+					"Permission": "s3:GetBucketObjectLockConfiguration",
+					"UseCases": [
+						"To retrieve the locking status of objects belonging to an S3 bucket."
+					]
+				},
+				{
+					"Permission": "s3:PutObjectRetention",
+					"UseCases": [
+						"To set object locks."
+					]
+				},
+				{
+					"Permission": "s3:PutBucketVersioning",
+					"UseCases": [
+						"To enable versioning on an S3 bucket."
+					]
+				},
+				{
+					"Permission": "s3:PutBucketObjectLockConfiguration",
+					"UseCases": [
+						"To enable object locking on an S3 bucket."
+					]
+				},
+				{
+					"Permission": "s3:ListBucketVersions",
+					"UseCases": [
+						"Used for operations on immutable buckets used in archival"
+					]
+				},
+				{
+					"Permission": "s3:ListObjectVersions",
+					"UseCases": [
+						"Used to list versions of object in a bucket"
+					]
+				},
+				{
+					"Permission": "s3:PutBucketTagging",
+					"UseCases": [
+						"To update tag on an S3 bucket."
+					]
+				},
+                {
+                    "Permission": "s3:PutBucketPolicy",
+                    "UseCases": [
+                        "To update the bucket policy of an S3 bucket."
+                    ]
+                }
+			],
+			"Resource": [
+				"*"
+			]
+		},
+		{
+			"Sid": "archivalStorageDeletePermissions",
+			"Effect": "Allow",
+			"Action": [
+				{
+					"Permission": "s3:DeleteObject",
+					"UseCases": [
+						"To delete the patch files of an archived snapshot in Rubrik buckets after the snapshot expires."
+					]
+				},
+				{
+					"Permission": "s3:DeleteObjectVersion",
+					"UseCases": [
+						"To delete the versions of patch files belonging to an archived snapshot in Rubrik buckets after the snapshot expires."
+					]
+				}
+			],
+			"Resource": [
+				"arn:*:s3:::rubrik*"
+			]
+		},
+		{
+			"Sid": "archivalKmsPermissions",
+			"Effect": "Allow",
+			"Action": [
+				{
+					"Permission": "kms:Encrypt",
+					"UseCases": [
+						"To encrypt the archived snapshot while uploading it to an archival location."
+					]
+				},
+				{
+					"Permission": "kms:Decrypt",
+					"UseCases": [
+						"To read the encrypted archived snapshot data."
+					]
+				},
+				{
+					"Permission": "kms:GenerateDataKeyWithoutPlaintext",
+					"UseCases": [
+						"To encrypt the archived snapshot data."
+					]
+				},
+				{
+					"Permission": "kms:GenerateDataKey",
+					"UseCases": [
+						"To encrypt the archived snapshot data."
+					]
+				},
+				{
+					"Permission": "kms:DescribeKey",
+					"UseCases": [
+						"To encrypt the archived snapshot data."
+					]
+				},
+				{
+					"Permission": "kms:ListAliases",
+					"UseCases": [
+						"To encrypt the archived snapshot data."
+					]
+				}
+			],
+			"Resource": [
+				"*"
+			]
+		}
+	],
+	"Version": "2012-10-17"
+}

--- a/permissions/archival/7.json
+++ b/permissions/archival/7.json
@@ -112,12 +112,12 @@
 						"To update tag on an S3 bucket."
 					]
 				},
-                {
-                    "Permission": "s3:PutBucketPolicy",
-                    "UseCases": [
-                        "To update the bucket policy of an S3 bucket."
-                    ]
-                }
+				{
+					"Permission": "s3:PutBucketPolicy",
+					"UseCases": [
+						"To update the bucket policy of an S3 bucket."
+					]
+				}
 			],
 			"Resource": [
 				"*"


### PR DESCRIPTION
# Description
Adds `s3:PutBucketPolicy` permission required for archival to S3 buckets

## Related Issue
SPARK-479677

## Motivation and Context
This change is required to enforce SSL-only access to S3 buckets used for cloud native archival.

## How Has This Been Tested?
UTs

## Screenshots (if appropriate):
![Screenshot 2025-06-11 at 3 00 16 PM](https://github.com/user-attachments/assets/a1e4648c-06ca-4d5d-8d78-b34596ca2d18)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/welcome-to-rubrik-build/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
