### PR TITLE
Restrict s3:PutBucketPolicy for archival S3 buckets to rubrik buckets

### DIFF
--- a/permissions/archival/7.json
+++ b/permissions/archival/7.json
@@ -111,16 +111,25 @@
 					"UseCases": [
 						"To update tag on an S3 bucket."
 					]
-				},
-				{
-					"Permission": "s3:PutBucketPolicy",
-					"UseCases": [
-						"To update the bucket policy of an S3 bucket."
-					]
 				}
 			],
 			"Resource": [
 				"*"
+			]
+		},
+		{
+			"Sid": "archivalStorageBucketPolicyPermissions",
+			"Effect": "Allow",
+			"Action": [
+				{
+					"Permission": "s3:PutBucketPolicy",
+					"UseCases": [
+						"To update the bucket policy of an archival S3 bucket."
+					]
+				}
+			],
+			"Resource": [
+				"arn:*:s3:::rubrik*"
 			]
 		},
 		{


### PR DESCRIPTION
# Description
Move `s3:PutBucketPolicy` to separate statement with ARNs restricted to
Rubrik-created S3 buckets `arn:*:s3:::rubrik*`.

## Related Issue
SPARK-479677

## Motivation and Context
This change makes the permission more fine-grained and removes the
possibility of blocking non-Rubrik buckets due to an excessively lax
bucket policy.

## How Has This Been Tested?
UTs

## Screenshots (if appropriate):
<img width="1728" alt="Screenshot 2025-06-23 at 7 58 19 PM" src="https://github.com/user-attachments/assets/fb63bf64-6664-4745-ad65-6bc14d62322f" />

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/welcome-to-rubrik-build/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
