### PR TITLE
Add `ec2:DescribeHosts` to EC2 permissions

### DIFF
--- a/permissions/ec2-protection/1025.json
+++ b/permissions/ec2-protection/1025.json
@@ -1,0 +1,552 @@
+{
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Action": [
+				{
+					"Permission": "ec2:DeleteSnapshot",
+					"UseCases": [
+						"Deleting EBS volume snapshots associated with expired backups.",
+						"Deleting associated snapshots when deleting an Amazon Machine Image (AMI) while reverting the Create EC2 instance snapshot task or exporting the EC2 instance snapshot to a different region.",
+						"Deleting snapshots when reverting the Create EBS volume snapshot task.",
+						"Deleting snapshots when exporting the EBS volume snapshot to a different region.",
+						"Deleting crash-consistent snapshots of excluded EBS volumes.",
+						"Deleting snapshot when deleting an AWS account.",
+						"Deleting snapshots after expiry.",
+						"Deleting temporary snapshots created during replication and export."
+					]
+				},
+				{
+					"Permission": "ec2:DeleteVolume",
+					"UseCases": [
+						"Deleting the EBS volumes launched from the backup if a restore or export EC2 instance task fails in the middle.",
+						"Deleting temporary EBS volume launched for file indexing and storage tiering."
+					]
+				},
+				{
+					"Permission": "ec2:TerminateInstances",
+					"UseCases": [
+						"Terminating EC2 instances created during failed exports."
+					]
+				},
+				{
+					"Permission": "ec2:RevokeSecurityGroupEgress",
+					"UseCases": [
+						"Removing the default egress rule from no connectivity security group for export EC2 instance in a powered off state."
+					]
+				}
+			],
+			"Resource": [
+				"*"
+			],
+			"Condition": {
+				"StringEquals": {
+					"ec2:ResourceTag/rk_component": "Cloud Native Protection"
+				}
+			}
+		},
+		{
+			"Effect": "Allow",
+			"Action": [
+				{
+					"Permission": "ebs:ListSnapshotBlocks",
+					"UseCases": [
+						"Getting the indices of blocks with data or the changed block indices that are used for optimal archival."
+					]
+				},
+				{
+					"Permission": "ebs:ListChangedBlocks",
+					"UseCases": [
+						"Getting the indices of blocks with data or the changed block indices that are used for optimal archival."
+					]
+				},
+				{
+					"Permission": "ebs:GetSnapshotBlock"
+				},
+				{
+					"Permission": "ebs:StartSnapshot"
+				},
+				{
+					"Permission": "ebs:PutSnapshotBlock"
+				},
+				{
+					"Permission": "ebs:CompleteSnapshot"
+				}
+			],
+			"Resource": [
+				"arn:*:ec2:*::snapshot/*"
+			],
+			"Condition": {
+				"StringEquals": {
+					"aws:ResourceTag/rk_component": "Cloud Native Protection"
+				}
+			}
+		},
+		{
+			"Effect": "Allow",
+			"Action": [
+				{
+					"Permission": "ec2:ModifyInstanceAttribute",
+					"UseCases": [
+						"Changing security groups of an EC2 instance from the no connectivity security group to a user-specified security group for export EC2 instance in a powered off state."
+					]
+				}
+			],
+			"Resource": [
+				"arn:*:ec2:*:*:instance/*"
+			],
+			"Condition": {
+				"StringEquals": {
+					"ec2:ResourceTag/rk_component": "Cloud Native Protection"
+				}
+			}
+		},
+		{
+			"Effect": "Allow",
+			"Action": [
+				{
+					"Permission": "ec2:ModifyInstanceAttribute",
+					"UseCases": [
+						"Changing security groups of an EC2 instance from the no connectivity security group to a user-specified security group for export EC2 instance in a powered off state."
+					]
+				}
+			],
+			"Resource": [
+				"arn:*:ec2:*:*:security-group/*"
+			]
+		},
+		{
+			"Effect": "Allow",
+			"Action": [
+				{
+					"Permission": "kms:CreateGrant",
+					"UseCases": [
+						"Enabling EC2 service to use the Customer Managed Key (CMK) on the behalf of the user.",
+						"Example: If an EBS volume snapshot is copied from key K1 to key K2, the EC2 service decrypts the K1 encrypted snapshot so that it can be encrypted to K2. To enable this, the EC2 service must be allowed to create grants for K1 and K2."
+					]
+				}
+			],
+			"Resource": [
+				"*"
+			],
+			"Condition": {
+				"Bool": {
+					"kms:GrantIsForAWSResource": true
+				},
+				"StringLike": {
+					"kms:ViaService": [
+						"ec2.*.amazonaws.com"
+					]
+				}
+			}
+		},
+		{
+			"Effect": "Allow",
+			"Action": [
+				{
+					"Permission": "iam:PassRole",
+					"UseCases": [
+						"Used to pass iam role to ec2 instance for cloud cluster ES."
+					]
+				}
+			],
+			"Resource": [
+				"arn:*:iam::*:role/rubrik-cces-*"
+			],
+			"Condition": {
+				"StringEquals": {
+					"iam:PassedToService": "ec2.amazonaws.com"
+				}
+			}
+		},
+		{
+			"Effect": "Allow",
+			"Action": [
+				{
+					"Permission": "iam:PassRole",
+					"UseCases": [
+						"Use to allow the passing of the worker node role to EC2 worker nodes and the master node role to the EKS cluster."
+					]
+				}
+			],
+			"Resource": [
+				"${user-provided-value}"
+			],
+			"Condition": {
+				"StringEquals": {
+					"iam:PassedToService": "ec2.amazonaws.com"
+				}
+			}
+		},
+		{
+			"Effect": "Allow",
+			"Action": [
+				{
+					"Permission": "ec2:AttachVolume",
+					"UseCases": [
+						"Restoring EC2 instances and attaching exported EBS volumes.",
+						"Exporting crash-consistent snapshot of an EC2 instance.",
+						"Exporting EBS volume and replacing it wherever attached.",
+						"Attaching the temporary EBS volume to Amazon Elastic Kubernetes Service (EKS) cluster for indexing and storage tiering."
+					]
+				},
+				{
+					"Permission": "ec2:CopyImage",
+					"UseCases": [
+						"Cross-region export of EC2 instances.",
+						"Cross-region replication of EC2 instance snapshots."
+					]
+				},
+				{
+					"Permission": "ec2:CopySnapshot",
+					"UseCases": [
+						"Cross-region export and replication of EBS volumes.",
+						"Cross-region export and replication of crash-consistent snapshots of EC2 instances."
+					]
+				},
+				{
+					"Permission": "ec2:CreateImage",
+					"UseCases": [
+						"Creating an image of an EC2 instance for backup."
+					]
+				},
+				{
+					"Permission": "ec2:CreateSnapshot",
+					"UseCases": [
+						"Creating a snapshot of an EBS volume for backup."
+					]
+				},
+				{
+					"Permission": "ec2:CreateSnapshots",
+					"UseCases": [
+						"Creating a crash-consistent snapshots of an EC2 instance."
+					]
+				},
+				{
+					"Permission": "ec2:CreateTags",
+					"UseCases": [
+						"Assigning metadata tags to the created resources such as EBS volumes, EC2 instances, images, and snapshots."
+					]
+				},
+				{
+					"Permission": "ec2:DescribeTags",
+					"UseCases": [
+						"Backing up the tags attached to an EC2 instance during backup.",
+						"Avoiding the tag limit while assigning tags to new resources."
+					]
+				},
+				{
+					"Permission": "ec2:CreateVolume",
+					"UseCases": [
+						"Exporting EBS volumes.",
+						"Restoring EC2 instances.",
+						"Exporting crash-consistent snapshot of an EC2 instance.",
+						"Creating temporary EBS volume to perform indexing for file search and recovery and storage tiering."
+					]
+				},
+				{
+					"Permission": "ec2:DeleteTags",
+					"UseCases": [
+						"Overwriting existing tags when restoring tags in the EC2 instance restore job.",
+						"Deleting Rubrik metadata tags when the tag limit is exceeded.",
+						"Deleting Garbage Collection (GC) tags when the GC task is no longer required for the resource."
+					]
+				},
+				{
+					"Permission": "ec2:RegisterImage"
+				},
+				{
+					"Permission": "ec2:DeregisterImage",
+					"UseCases": [
+						"Deleting the AMI associated with an expired backup.",
+						"Deleting image in undo of the EC2 instance snapshot task.",
+						"Deleting image after copying it to a new region during the cross-region export.",
+						"Deleting AMIs after a snapshot expiry.",
+						"Deleting any temporary AMI created during replication and export."
+					]
+				},
+				{
+					"Permission": "ec2:DescribeAvailabilityZones",
+					"UseCases": [
+						"Retrieving the list of availability zones while exporting EBS volume and EC2 instance snapshots."
+					]
+				},
+				{
+					"Permission": "ec2:DescribeImages",
+					"UseCases": [
+						"Tracking the image creation status in the EC2 backup task.",
+						"Retrieving image details for the recovery tasks.",
+						"Periodically ensuring that the AMI associated with RSC backups is still available and not deleted by an external actor."
+					]
+				},
+				{
+					"Permission": "ec2:DescribeInstances",
+					"UseCases": [
+						"Retrieving the list of EC2 instances during the refresh task.",
+						"Retrieving instance details during snapshot and recovery tasks."
+					]
+				},
+				{
+					"Permission": "ec2:DescribeHosts",
+					"UseCases": [
+						"Retrieving the state of dedicated hosts for EC2 instance recovery tasks."
+					]
+				},
+				{
+					"Permission": "ec2:DescribeInstanceTypeOfferings",
+					"UseCases": [
+						"Retrieving the list of EC2 instances types during the VM export flow."
+					]
+				},
+				{
+					"Permission": "ec2:DescribeKeyPairs",
+					"UseCases": [
+						"Retrieving the list of SSH key pairs during the virtual machine recovery.",
+						"Tracking the associated key pairs for EC2 instances when a backup is taken."
+					]
+				},
+				{
+					"Permission": "ec2:DescribeSecurityGroups",
+					"UseCases": [
+						"Retrieving the list of security groups during the account refresh task.",
+						"Retrieving the list of security groups while exporting EC2 instance snapshots."
+					]
+				},
+				{
+					"Permission": "ec2:DescribeSnapshots",
+					"UseCases": [
+						"Tracking the snapshot creation status during the EBS volume snapshot task.",
+						"Retrieving snapshot details for the recovery tasks.",
+						"Periodically ensuring that the snapshot associated with RSC backups is still available and not deleted by an external actor, for example, an user-initiated script."
+					]
+				},
+				{
+					"Permission": "ec2:DescribeSubnets",
+					"UseCases": [
+						"Retrieving the list of subnets during the account refresh task.",
+						"Retrieving the list of subnets while exporting EC2 instance snapshots."
+					]
+				},
+				{
+					"Permission": "ec2:DescribeVolumes",
+					"UseCases": [
+						"Retrieving the list of EBS Volumes during the refresh task.",
+						"Retrieving volume details in various snapshot and recovery tasks."
+					]
+				},
+				{
+					"Permission": "ec2:DescribeVpcs",
+					"UseCases": [
+						"Retrieving the list of all Virtual Private Clouds (VPC) while exporting EC2 instance snapshots.",
+						"Retrieving the list of VPCs during the account refresh task."
+					]
+				},
+				{
+					"Permission": "ec2:DetachVolume",
+					"UseCases": [
+						"Detaching the existing volumes to replace them with recovered copies during the restore EC2 instance.",
+						"Detaching an existing EBS volume when the Replace where attached option is selected at the time of exporting an EBS volume.",
+						"Detaching the EBS volume from the temporary EKS cluster when the file search is enabled for an EC2 instance or EBS volume."
+					]
+				},
+				{
+					"Permission": "ec2:ModifyImageAttribute",
+					"UseCases": [
+						"Modifying the description of EC2 instance snapshots created by RSC.",
+						"The image description is used for identifying all GC leaked images."
+					]
+				},
+				{
+					"Permission": "ec2:RunInstances",
+					"UseCases": [
+						"Launching a virtual machine from a backup."
+					]
+				},
+				{
+					"Permission": "ec2:StartInstances",
+					"UseCases": [
+						"Starting a virtual machine that was restored with new disks."
+					]
+				},
+				{
+					"Permission": "ec2:StopInstances",
+					"UseCases": [
+						"Stopping an EC2 instance. When restoring a virtual machine, disks can only be replaced when the EC2 instance is stopped."
+					]
+				},
+				{
+					"Permission": "kms:Decrypt",
+					"UseCases": [
+						"Performing the custom CMK flow while exporting EC2 instance or EBS volume."
+					]
+				},
+				{
+					"Permission": "kms:DescribeKey",
+					"UseCases": [
+						"Performing the custom CMK flow while exporting EC2 instance or EBS volume."
+					]
+				},
+				{
+					"Permission": "kms:Encrypt",
+					"UseCases": [
+						"Performing the custom CMK flow while exporting EC2 instance or EBS volume."
+					]
+				},
+				{
+					"Permission": "kms:GenerateDataKey",
+					"UseCases": [
+						"Performing the custom CMK flow while exporting EC2 instance or EBS volume."
+					]
+				},
+				{
+					"Permission": "kms:GenerateDataKeyWithoutPlaintext",
+					"UseCases": [
+						"Performing the custom CMK flow while exporting EC2 instance or EBS volume."
+					]
+				},
+				{
+					"Permission": "kms:ListKeys",
+					"UseCases": [
+						"Displaying Key Management Service (KMS) keys for the AWS account in a region."
+					]
+				},
+				{
+					"Permission": "kms:ListAliases",
+					"UseCases": [
+						"Displaying KMS aliases for the AWS account in a region."
+					]
+				},
+				{
+					"Permission": "kms:ReEncryptFrom",
+					"UseCases": [
+						"Performing the custom CMK flow while exporting EC2 instance or EBS volume."
+					]
+				},
+				{
+					"Permission": "kms:ReEncryptTo",
+					"UseCases": [
+						"Performing the custom CMK flow while exporting EC2 instance or EBS volume."
+					]
+				},
+				{
+					"Permission": "ec2:DescribeVolumeAttribute",
+					"UseCases": [
+						"Allowing RSC to identify EBS volumes launched from the AWS marketplace. You cannot perform file recovery and storage tiering for marketplace EBS volumes."
+					]
+				},
+				{
+					"Permission": "ec2:DescribeSnapshotAttribute",
+					"UseCases": [
+						"Performing a check to determine if an EBS volume snapshot is from the AWS marketplace or not."
+					]
+				},
+				{
+					"Permission": "ec2:ModifySnapshotAttribute",
+					"UseCases": [
+						"Sharing EBS snapshots with other AWS accounts for cross-account replication."
+					]
+				},
+				{
+					"Permission": "s3:ListAllMyBuckets",
+					"UseCases": [
+						"It is used when listing S3 bucket endpoints."
+					]
+				},
+				{
+					"Permission": "s3:ListBucket",
+					"UseCases": [
+						"Listing bucket objects and checking if the bucket exists. It is used in the download job."
+					]
+				},
+				{
+					"Permission": "s3:AbortMultipartUpload",
+					"UseCases": [
+						"Performing the multipart upload. It is used in the file recovery job."
+					]
+				},
+				{
+					"Permission": "s3:CreateBucket",
+					"UseCases": [
+						"Creating a bucket. It is used in the file recovery job."
+					]
+				},
+				{
+					"Permission": "s3:PutObject",
+					"UseCases": [
+						"Uploading objects. It is used in the file recovery job."
+					]
+				},
+				{
+					"Permission": "s3:PutObjectTagging",
+					"UseCases": [
+						"Adding tags to s3 objects"
+					]
+				},
+				{
+					"Permission": "s3:PutBucketTagging",
+					"UseCases": [
+						"Adding tags to S3 buckets. It is used in the file recovery job."
+					]
+				},
+				{
+					"Permission": "s3:GetBucketObjectLockConfiguration",
+					"UseCases": [
+						"Obtaining object lock configuration for bucket. This is needed for cc-provision"
+					]
+				},
+				{
+					"Permission": "s3:GetBucketVersioning",
+					"UseCases": [
+						"Obtaining versioning configuration for bucket. This is needed for cc-provision"
+					]
+				},
+				{
+					"Permission": "ec2:GetEbsEncryptionByDefault",
+					"UseCases": [
+						"Checking if EBS encryption by default is enabled in the AWS customer account and region."
+					]
+				},
+				{
+					"Permission": "ec2:CreateSecurityGroup",
+					"UseCases": [
+						"Creating a security group, without connectivity, for exporting AWS virtual machines that are powered off."
+					]
+				},
+				{
+					"Permission": "iam:ListInstanceProfiles",
+					"UseCases": [
+						"Listing the IAM instance profiles for associating them with EC2 instances for s3 bucket access."
+					]
+				},
+				{
+					"Permission": "ec2:AssociateIamInstanceProfile",
+					"UseCases": [
+						"Associating an IAM instance profile with an EC2 instance during EC2 export."
+					]
+				},
+				{
+					"Permission": "ec2:ReplaceIamInstanceProfileAssociation",
+					"UseCases": [
+						"Replacing an IAM instance profile for the EC2 instance during EC2 export."
+					]
+				},
+				{
+					"Permission": "ec2:ModifyVolume",
+					"UseCases": [
+						"Checking if parameters of a EBS volume like volume size, volume type etc can be modified."
+					]
+				},
+				{
+					"Permission": "ec2:DescribeVolumesModifications",
+					"UseCases": [
+						"Describing the most recent volume modification request for the specified EBS volumes."
+					]
+				}
+			],
+			"Resource": [
+				"*"
+			]
+		}
+	],
+	"Version": "2012-10-17"
+}


### PR DESCRIPTION
# Description
We require `ec2:DescribeHosts` to use EC2's `DescribeHosts` API
to poll for the state of dedicated hosts when recovering Mac EC2 instances.

## Related Issue
SPARK-575788

## Motivation and Context

## How Has This Been Tested?
Permission Parity UT

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/welcome-to-rubrik-build/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
